### PR TITLE
feat: support select on redirectContentType for additional fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ In this step all data required to calculate sitemap is fetched and stored in int
 | titleFieldId      |         | Id of the field that represents the page title. This field should be of type `Symbol`.                                                                                                          |
 | slugFieldId       |         | **Required**. Id of the field that represents the page slug that should match the following regexp `^((\/)\|(([\/\w\-\._~:!$&'\(\)*+,;@]\|(%\d+))+))$`. This field should be of type  `Symbol`. |
 | childPagesFieldId |         | Id of the field that represents the references to child pages. This field should be of type `Array` and include references to other entries that were configured as pages.                      |
+| select            |         | Array of additional field ids that should be fetched and exposed on pages via `additionalFields`.                                                                                               |
 ### Contentful redirect content type configuration
 | Name         | Default | Description                                                                                                                                                                         |
 |--------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -164,6 +165,7 @@ In this step all data required to calculate sitemap is fetched and stored in int
 | typeFieldId  |         | **Required**. Id of the field that represents the redirect type (should be either `alias` or `redirect`). This field should be of type `Symbol`.                                    |
 | pageFieldId  |         | **Required**. Id of the field that represents the page reference. This field should be of type `Link` and accept references only to entries that were configured as pages.          |
 | pathFieldId  |         | **Required**. Id of the field that represents the redirect path that should match the following regexp `\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?$`. This field should be of type `Symbol`. |
+| select       |         | Array of additional field ids that should be fetched and exposed on redirects/aliases via `additionalFields`.                                                                        |
 
 # Basic usage
 

--- a/src/arboretum-client.ts
+++ b/src/arboretum-client.ts
@@ -31,6 +31,7 @@ export type ArboretumClientContentfulConfigOptionsT = {
     pageFieldId: string;
     pathFieldId: string;
     typeFieldId: string;
+    select?: Array<string>;
   };
   homePageTagId?: string;
 };
@@ -116,11 +117,13 @@ type ArboretumPageBaseT = {
 export type ArboretumRedirectT = ArboretumPageBaseT & {
   type: "redirect";
   pageId: string;
+  additionalFields?: { [key: string]: any };
 };
 
 export type ArboretumAliasT = ArboretumPageBaseT & {
   type: "alias";
   pageId: string;
+  additionalFields?: { [key: string]: any };
 };
 
 export type ArboretumPageT = ArboretumPageBaseT & {

--- a/src/impl/arboretum-client.impl.ts
+++ b/src/impl/arboretum-client.impl.ts
@@ -64,6 +64,7 @@ export type RedirectT = {
   title?: string;
   type: "redirect" | "alias";
   page: { sys: { id: string } };
+  additionalFields?: { [key: string]: any };
 };
 export type RedirectIdT = RedirectT["sys"]["id"];
 export type RedirectPathT = RedirectT["path"];

--- a/src/impl/data/redirect-entries.ts
+++ b/src/impl/data/redirect-entries.ts
@@ -23,6 +23,7 @@ const getAllRedirectEntriesRecursively = async (
     redirectContentType.pageFieldId,
     redirectContentType.typeFieldId,
     redirectContentType.pathFieldId,
+    ...(redirectContentType.select || []),
   ].flatMap((id) => (id ? [`fields.${id}`] : []));
 
   return getAllEntriesRecursively(
@@ -31,28 +32,7 @@ const getAllRedirectEntriesRecursively = async (
     redirectContentType.id,
     skip,
     acc,
-    /* For some reason select param causes errors in CMA. I'm getting the following response: 
-  {
-    "status": 400,
-    "statusText": "Bad Request",
-    "message": "The query you sent was invalid. Probably a filter or ordering specification is not applicable to the type of a field.",
-    "details": {
-      "errors": [
-        {
-          "name": "select",
-          "details": "Select is only applicable when querying a collection of entities."
-        }
-      ]
-    },
-    "request": {
-      "url": "/spaces/8h4rcnu50txt/environments/dacjan-test/public/entries",
-      "method": "get",
-      ...
-    },
-}*/
-    select || ctx.contentfulClientType === "cma-client"
-      ? undefined
-      : ["sys", "metadata", ...fieldsSelect].join(","),
+    select ?? ["sys", "metadata", ...fieldsSelect].join(","),
     [redirectContentType.pageFieldId]
   );
 };

--- a/src/impl/sitemap/adapters/redirect-entry-adapter.ts
+++ b/src/impl/sitemap/adapters/redirect-entry-adapter.ts
@@ -1,4 +1,4 @@
-import { PageT, RedirectT } from "../../arboretum-client.impl";
+import { ArboretumClientCtx, PageT, RedirectT } from "../../arboretum-client.impl";
 import {
   ContentTypeT,
   EntryT,
@@ -8,7 +8,8 @@ import { SitemapDataT } from "../../data/sitemap-data";
 import { localizeField } from "../helpers/localize-contentful-field";
 
 export const redirectEntryAdapter = (
-  data: Pick<SitemapDataT, "locales" | "defaultLocaleCode">,
+  data: Pick<SitemapDataT, "locales" | "defaultLocaleCode" | "contentTypes">,
+  options: NonNullable<ArboretumClientCtx["options"]["redirectContentType"]>,
   pageField: ContentTypeT["fields"][number],
   pathField: ContentTypeT["fields"][number],
   typeField: ContentTypeT["fields"][number],
@@ -36,6 +37,25 @@ export const redirectEntryAdapter = (
     : undefined;
   const pageSysId = page?.sys?.id;
 
+  const contentTypeId = entry.sys.contentType.sys.id;
+
+  /* Only set when "select" is configured so that redirects built from configs
+     without it keep their previous shape */
+  const additionalFields = options.select
+    ? options.select.reduce((acc, fieldId) => {
+        const contentType = data.contentTypes.get(contentTypeId);
+        if (contentType) {
+          const field = contentType.fields.get(fieldId);
+          const value = field
+            ? fieldValue(field.localized, entry.fields[field.id])
+            : undefined;
+          acc[fieldId] = value;
+        }
+
+        return acc;
+      }, {} as { [key: string]: any })
+    : undefined;
+
   return pageSysId && path && (type === "redirect" || type === "alias")
     ? {
         page: { sys: { id: pageSysId } },
@@ -47,8 +67,9 @@ export const redirectEntryAdapter = (
         sys: {
           id: entry.sys.id,
           cmaOnlyStatus: entry.sys.cmaOnlyStatus,
-          contentTypeId: entry.sys.contentType.sys.id,
+          contentTypeId,
         },
+        additionalFields,
       }
     : undefined;
 };

--- a/src/impl/sitemap/adapters/redirect-to-arboretum-page-adapter.ts
+++ b/src/impl/sitemap/adapters/redirect-to-arboretum-page-adapter.ts
@@ -13,4 +13,5 @@ export const redirectToArboretumPage =
     cmaOnlyStatus: redirect.sys.cmaOnlyStatus,
     title: redirect.title,
     metadata: redirect.metadata,
+    additionalFields: redirect.additionalFields,
   });

--- a/src/impl/sitemap/helpers/build-localized-sitemap.test.ts
+++ b/src/impl/sitemap/helpers/build-localized-sitemap.test.ts
@@ -217,6 +217,121 @@ describe(buildLocalizedSitemap, () => {
     );
   });
 
+  test("Redirect select fields are exposed as additionalFields", () => {
+    const pageHomeTagId: ArboretumClientCtx["pageHomeTagId"] = "pagHome";
+    const redirectNoteFieldId = "note";
+
+    const contentTypesWithNoteField = new Map(contentTypes);
+    const redirectContentTypeDef = contentTypes.get(redirectContentTypeId)!;
+    contentTypesWithNoteField.set(redirectContentTypeId, {
+      sys: redirectContentTypeDef.sys,
+      fields: new Map([
+        ...redirectContentTypeDef.fields,
+        [
+          redirectNoteFieldId,
+          {
+            id: redirectNoteFieldId,
+            localized: true,
+            name: "Note",
+            type: "Symbol",
+          },
+        ],
+      ]),
+    });
+
+    const optionsWithSelect: ArboretumClientCtx["options"] = {
+      ...options,
+      redirectContentType: {
+        ...options.redirectContentType!,
+        select: [redirectNoteFieldId, "nonExistentField"],
+      },
+    };
+
+    const pagesEntries = mockedPages.flatMap((page) =>
+      page.type === "page"
+        ? [pageToEntry(page, page.sys.id === "root" ? [pageHomeTagId] : [])]
+        : []
+    );
+
+    const redirectsEntries = mockedPages.flatMap((page) =>
+      page.type !== "page"
+        ? [
+            {
+              ...redirectToEntry(page),
+              fields: {
+                ...redirectToEntry(page).fields,
+                [redirectNoteFieldId]: {
+                  [defaultLocale.code]: `note-${page.sys.id}`,
+                },
+              },
+            },
+          ]
+        : []
+    );
+
+    const data: Pick<
+      ArboretumClientCtx["data"],
+      | "homePagesByTagId"
+      | "pages"
+      | "contentTypes"
+      | "defaultLocaleCode"
+      | "locales"
+      | "redirects"
+    > = {
+      contentTypes: contentTypesWithNoteField,
+      defaultLocaleCode: defaultLocale.code,
+      locales: new Map([[defaultLocale.code, defaultLocale]]),
+      homePagesByTagId: new Map([
+        [
+          defaultLocale.code,
+          new Map([[pageHomeTagId, [{ sys: { id: mockedRoot.sys.id } }]]]),
+        ],
+      ]),
+      pages: new Map(pagesEntries.map((e) => [e.sys.id, e])),
+      redirects: redirectsEntries,
+    };
+
+    const sitemapE = buildLocalizedSitemap(
+      data,
+      optionsWithSelect,
+      pageHomeTagId,
+      defaultLocale
+    );
+
+    expect(sitemapE._tag).toBe("Right");
+    if (sitemapE._tag === "Right") {
+      const redirects = [...sitemapE.right.sitemap.values()].filter(
+        (p): p is RedirectT => p.type === "redirect" || p.type === "alias"
+      );
+      expect(redirects.length).toBeGreaterThan(0);
+      redirects.forEach((redirect) => {
+        expect(redirect.additionalFields).toEqual({
+          [redirectNoteFieldId]: `note-${redirect.sys.id}`,
+          nonExistentField: undefined,
+        });
+      });
+    }
+
+    /* Backward compatibility: without "select", additionalFields stays undefined */
+    const sitemapWithoutSelectE = buildLocalizedSitemap(
+      data,
+      options,
+      pageHomeTagId,
+      defaultLocale
+    );
+
+    expect(sitemapWithoutSelectE._tag).toBe("Right");
+    if (sitemapWithoutSelectE._tag === "Right") {
+      const redirects = [...sitemapWithoutSelectE.right.sitemap.values()].filter(
+        (p): p is RedirectT => p.type === "redirect" || p.type === "alias"
+      );
+      expect(redirects.length).toBeGreaterThan(0);
+      redirects.forEach((redirect) => {
+        expect(redirect.additionalFields).toBeUndefined();
+      });
+    }
+  });
+
   test("Handle reference cycles", () => {
     const pageHomeTagId: ArboretumClientCtx["pageHomeTagId"] = "pagHome";
 

--- a/src/impl/sitemap/helpers/build-localized-sitemap.ts
+++ b/src/impl/sitemap/helpers/build-localized-sitemap.ts
@@ -46,6 +46,7 @@ const getAllRedirects = (
       pageField && pathField && typeField
         ? redirectEntryAdapter(
             data,
+            options,
             pageField,
             pathField,
             typeField,


### PR DESCRIPTION
Adds an optional `select` array to the `redirectContentType` config, mirroring the existing `select` option on `pageContentTypes`. Selected fields are fetched from Contentful and exposed on redirect/alias nodes via a new optional `additionalFields` property (localized with the same fallback behavior as other redirect fields).

Closes #7